### PR TITLE
Added /STER/pythonrepo/ path to config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,22 +13,23 @@ import glob as glob_module
 
 #-- You can add directories here, but be sure that the relative paths within
 #   those directories are correct!
-data_dirs = [os.getenv('ivsdata'),'/STER/pieterd/IVSDATA/', '/STER/kristofs/IVSdata','/STER/jorisv/IVSDATA/', 
-             '/STER/kenneth/Python_repository/','/home/ben/public_html/opacities','/STER/michelh/IVSDATA/']
-             
+data_dirs = [os.getenv('ivsdata'),'/STER/pieterd/IVSDATA/', '/STER/kristofs/IVSdata','/STER/jorisv/IVSDATA/',
+             '/STER/kenneth/Python_repository/','/home/ben/public_html/opacities','/STER/michelh/IVSDATA/',
+             '/STER/pythonrepo/']
+
 ivs_dirs = dict(coralie='/STER/coralie/',
                 hermes='/STER/mercator/hermes/')
-         
+
 
 
 def get_datafile(relative_path,basename):
     """
     Reconstruct the location of a data file and check whether it exists.
-    
+
     If the file exists, it will return the absolute path of the filename.
-    
+
     If the file does not exist, it will raise an IOError.
-    
+
     @param relative_path: relative path starting from main data directory tree
     @type relative_path: str
     @param basename: filename
@@ -38,16 +39,16 @@ def get_datafile(relative_path,basename):
     """
     for data_dir in data_dirs:
         if data_dir is None: continue
-        
+
         filename = os.path.join(data_dir,relative_path,basename)
-        
+
         if os.path.isfile(filename):
             break
     else:
         str_data_dirs = ", ".join([idir for idir in data_dirs if idir is not None])
         relative_file = os.path.join(relative_path,basename)
         raise IOError, "File %s not found in any of the specified data directories %s"%(relative_file,str_data_dirs)
-    
+
     return filename
 
 
@@ -56,7 +57,7 @@ def get_datafile(relative_path,basename):
 def glob(relative_path,arg='*'):
     """
     Glob the files in a relative path.
-    
+
     @param relative_path: relative path starting from main data directory tree
     @type relative_path: str
     @param arg: argument to use in glob
@@ -70,17 +71,17 @@ def glob(relative_path,arg='*'):
         files += glob_module.glob(os.path.join(data_dir,relative_path,arg))
     files.sort()
     return files
-    
 
 
 
-if __name__=="__main__":    
+
+if __name__=="__main__":
     import subprocess
     from ivs.aux import loggers
     import shutil
     import time
     logger = loggers.get_basic_logger()
-    
+
     to_install = ['spectra/pyrotin4',
                   'timeseries/deeming','timeseries/eebls','timeseries/multih',
                   'timeseries/pyclean','timeseries/pyKEP','timeseries/pyscargle',


### PR DESCRIPTION
An additional path was appended to the data directories list in
config.py . This new /STER/pythonrepo/ path will substitute the other
user paths (e.g. petered, kristofs, juries, etc) as the go-to place for
reference data, called by the scripts of the IvS python repository.
For now the user paths are left as-were, but users of the repository
are encouraged to change their paths to the new /STER/pythonrepo/
directory.